### PR TITLE
降低实时计算消耗

### DIFF
--- a/runtime/run_rt.py
+++ b/runtime/run_rt.py
@@ -100,6 +100,10 @@ class VCRunner:
         self.vc_spk_emb = extract_embedding(self.spk_model, target_wav, device=device)
         print(f"[Init] Speaker embedding shape: {self.vc_spk_emb.shape}")
 
+        # Precompute GTM KV — speaker is fixed for the entire session
+        with torch.no_grad():
+            self.vc_gtm_kv = self.vc.gtm(self.vc_spk_emb)
+      
         # --- Streaming parameters ---
         self.chunk_size = 12 if model == "120ms" else 4
         self.block_size = 4
@@ -240,7 +244,7 @@ class VCRunner:
                     x, t_tensor, r_tensor,
                     cache=None, cond=cond, spks=self.vc_spk_emb,
                     offset=self.vc_offset, is_inference=True,
-                    kv_cache=pre_kv_cache,
+                    kv_cache=pre_kv_cache, gtm_kv=self.vc_gtm_kv,
                 )
                 x = x - dt * u
 

--- a/runtime/src/dit.py
+++ b/runtime/src/dit.py
@@ -282,6 +282,7 @@ class DiT(nn.Module):
         is_uncondition: bool = False,
         cfg_mask=None,  # [B] classifier-free guidance mask
         kv_cache=None,  # list of (k, v) tuples per layer
+        gtm_kv=None,    # precomputed (k_mem, v_mem) — skip GTM when provided
     ):
         batch, seq_len = x.shape[0], x.shape[1]
 
@@ -291,7 +292,10 @@ class DiT(nn.Module):
         t_emb = t_emb + r_emb
 
         # ---- GTM: speaker → timbre memory KV ----
-        k_mem, v_mem = self.gtm(spks)  # spks: [B, 256]
+        if gtm_kv is not None:
+            k_mem, v_mem = gtm_kv
+        else:
+            k_mem, v_mem = self.gtm(spks)  # spks: [B, 256]
 
         # ---- TVT: frame BN × GTM → time-varying timbre condition ----
         timbre_cond = self.temporal_timbre(cond, k_mem, v_mem)  # [B, T, bn_dim]


### PR DESCRIPTION
在每个 chunk 的每次 ODE step，UTTE模块前2 层 MLP（mlp_k、mlp_v）输出可以预先缓存，节省部分计算量，降低RTF。 