### PR TITLE
关闭run_rt.py的cudnn

### DIFF
--- a/runtime/run_rt.py
+++ b/runtime/run_rt.py
@@ -84,7 +84,8 @@ class VCRunner:
     def __init__(self, target_wav: str, device: str = "cpu", model: str = "120ms"):
         self.device = device
         torch.set_num_threads(1)
-
+        torch.backends.cudnn.enabled = False  # disable cuDNN for GPU Conv2d consistency with training data
+      
         paths = MODEL_PATHS[model]
         vc_ckpt = paths["ckpt"]
         vc_config = paths["config"]


### PR DESCRIPTION
fastu2pp训练设置cudnn=false，run_rt不显示设置false会默认开启导致误差。